### PR TITLE
ACMS-1221: Admin toolbar styles doesn't match with current Acquia CMS profile, when site is installed using Starter kit

### DIFF
--- a/acquia_cms_toolbar.info.yml
+++ b/acquia_cms_toolbar.info.yml
@@ -5,3 +5,4 @@ package: "Acquia CMS"
 type: module
 dependencies:
   - admin_toolbar:admin_toolbar
+  - admin_toolbar:admin_toolbar_tools


### PR DESCRIPTION
Admin toolbar styles doesn't match with current Acquia CMS profile, when site is installed using Starter kit